### PR TITLE
turn off spellcheck in main textarea

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -11,7 +11,7 @@
         <form class ="ms-auto" action="/server/run" method="POST">
             <div>
                 <label class="form-label" for="code">Source:</label>
-                <textarea class="pb-auto form-control" id="code" name="code" rows="5" required="" placeholder="const std = ..."></textarea>
+                <textarea class="pb-auto form-control" id="code" name="code" rows="5" required="" placeholder="const std = ..." spellcheck="false"></textarea>
             </div>
             <div>
                 <button type="submit" class="pt-auto btn btn-primary">Compile</button>


### PR DESCRIPTION
I don't have a quick way to test this, but it's a small change that would kill the red squigglies in the playground, unless I've made a typo.