### PR TITLE
Fix Placeholder Program Compile Error

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -41,7 +41,7 @@
 	<main>
 		<h1>Zig Playground</h1>
 		<p>Source:</p>
-		<textarea id="code" placeholder="const std = ..." spellcheck="false">const std = @import("std"); pub fn main() void { std.debug.print("Hello, {}!", .{"world"}); }</textarea>
+		<textarea id="code" placeholder="const std = ..." spellcheck="false">const std = @import("std"); pub fn main() void { std.debug.print("Hello, {s}!", .{"world"}); }</textarea>
 		<button onclick="runCode()">Compile</button>
 		<div id="stdout"></div>
 	</main>


### PR DESCRIPTION
Hi, 

Really nice work with https://zig-play.dev/
I visited the page and found out the default placeholder in the `Source:` text box does not compile. The following PR fixes this issue.

**Issue:**

For the current placeholder

```
const std = @import("std"); pub fn main() void { std.debug.print("Hello, {}!", .{"world"}); }
```

It fails to compile with the error in `stdout`

```
An error occurred:
/usr/local/bin/lib/std/fmt.zig:519:25: error: cannot format array ref without a specifier (i.e. {s} or {*})
                        @compileError("cannot format array ref without a specifier (i.e. {s} or {*})");
                        ^
/usr/local/bin/lib/std/fmt.zig:352:23: note: called from here
        try formatType(
                      ^
/usr/local/bin/lib/std/io/writer.zig:34:34: note: called from here
            return std.fmt.format(self, format, args);
                                 ^
/usr/local/bin/lib/std/debug.zig:68:27: note: called from here
    nosuspend stderr.print(fmt, args) catch return;
                          ^
/tmp/playground092885291/play.zig:1:65: note: called from here
const std = @import("std"); pub fn main() void { std.debug.print("Hello, {}!", .{"world"}); }
                                                                ^
/tmp/playground092885291/play.zig:1:48: note: called from here
const std = @import("std"); pub fn main() void { std.debug.print("Hello, {}!", .{"world"}); }
                                               ^
```

Adding the specifier now fixes this

```
const std = @import("std"); pub fn main() void { std.debug.print("Hello, {s}!", .{"world"}); }
```