### PR TITLE
Added Zig Fmt Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ a cheap option considering their generous free tier.
 ### FAQ
 > What can this playground do?
 
-It is currently set up to simply run a single Zig source file. (i.e. `zig run source.zig`)
+It is currently set up to simply run and format a single Zig source file. (i.e. `zig run source.zig` & `zig fmt source.zig`)
 
 > Are there any timeouts?
 

--- a/handlers.go
+++ b/handlers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"

--- a/handlers.go
+++ b/handlers.go
@@ -58,3 +58,53 @@ func Run(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "writing response", http.StatusInternalServerError)
 	}
 }
+
+func Fmt(w http.ResponseWriter, r *http.Request) {
+	const defaultZig = "/usr/local/bin/zig"
+
+	var zigExe string
+	foundZigExe, zigExeErr := exec.LookPath("zig")
+	if zigExeErr != nil {
+		zigExe = defaultZig
+	} else {
+		zigExe = foundZigExe
+	}
+
+	// Limit how big a source file can be. 5MB here.
+	r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024)
+	zigSource, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "reading body", http.StatusInternalServerError)
+		return
+	}
+	defer r.Body.Close()
+
+	// Set up the temporary resources.
+	dir, err := ioutil.TempDir("", "playground")
+	if err != nil {
+		http.Error(w, "creating temporary directory", http.StatusInternalServerError)
+		return
+	}
+	defer os.RemoveAll(dir)
+
+	tmpSource := filepath.Join(dir, "play.zig")
+	if err := ioutil.WriteFile(tmpSource, []byte(zigSource), 0666); err != nil {
+		http.Error(w, "copying zig source", http.StatusInternalServerError)
+		return
+	}
+
+	// Currently we cap format times at ten seconds.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := fmt.Sprintf("cat %s | %s fmt --stdin", tmpSource, zigExe)
+	output, err := exec.CommandContext(ctx, "bash", "-c", cmd).CombinedOutput()
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	_, err = w.Write(output)
+	if err != nil {
+		http.Error(w, "writing response", http.StatusInternalServerError)
+	}
+}

--- a/handlers.go
+++ b/handlers.go
@@ -11,42 +11,55 @@ import (
 	"time"
 )
 
-func Run(w http.ResponseWriter, r *http.Request) {
-	const defaultZig = "/usr/local/bin/zig"
+const (
+	defaultZig  = "/usr/local/bin/zig"
+	maxFileSize = 5 * 1024 * 1024
+	maxCompTime = 10 * time.Second
+)
 
-	var zigExe string
+func initZig() string {
 	foundZigExe, zigExeErr := exec.LookPath("zig")
 	if zigExeErr != nil {
-		zigExe = defaultZig
-	} else {
-		zigExe = foundZigExe
+		return defaultZig
 	}
+	return foundZigExe
+}
 
-	// Limit how big a source file can be. 5MB here.
-	r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024)
-	zigSource, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "reading body", http.StatusInternalServerError)
-		return
-	}
-	defer r.Body.Close()
-
+func setupPlayground(w http.ResponseWriter, r *http.Request) (string, string, error) {
 	// Set up the temporary resources.
 	dir, err := ioutil.TempDir("", "playground")
 	if err != nil {
-		http.Error(w, "creating temporary directory", http.StatusInternalServerError)
+		return "", "", err
+	}
+
+	// Limit how big a source file can be. 5MB here.
+	r.Body = http.MaxBytesReader(w, r.Body, maxFileSize)
+	zigSource, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	tmpSource := filepath.Join(dir, "play.zig")
+	if err := ioutil.WriteFile(tmpSource, []byte(zigSource), 0666); err != nil {
+		return "", "", err
+	}
+
+	return dir, tmpSource, nil
+}
+
+func Run(w http.ResponseWriter, r *http.Request) {
+	zigExe := initZig()
+	defer r.Body.Close()
+
+	dir, tmpSource, err := setupPlayground(w, r)
+	if err != nil {
+		http.Error(w, "reading source", http.StatusInternalServerError)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	tmpSource := filepath.Join(dir, "play.zig")
-	if err := ioutil.WriteFile(tmpSource, []byte(zigSource), 0666); err != nil {
-		http.Error(w, "copying zig source", http.StatusInternalServerError)
-		return
-	}
-
 	// Currently we cap compilation times at ten seconds.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), maxCompTime)
 	defer cancel()
 
 	output, err := exec.CommandContext(ctx, zigExe, "run", tmpSource).CombinedOutput()
@@ -61,41 +74,18 @@ func Run(w http.ResponseWriter, r *http.Request) {
 }
 
 func Fmt(w http.ResponseWriter, r *http.Request) {
-	const defaultZig = "/usr/local/bin/zig"
-
-	var zigExe string
-	foundZigExe, zigExeErr := exec.LookPath("zig")
-	if zigExeErr != nil {
-		zigExe = defaultZig
-	} else {
-		zigExe = foundZigExe
-	}
-
-	// Limit how big a source file can be. 5MB here.
-	r.Body = http.MaxBytesReader(w, r.Body, 5*1024*1024)
-	zigSource, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "reading body", http.StatusInternalServerError)
-		return
-	}
+	zigExe := initZig()
 	defer r.Body.Close()
 
-	// Set up the temporary resources.
-	dir, err := ioutil.TempDir("", "playground")
+	dir, tmpSource, err := setupPlayground(w, r)
 	if err != nil {
-		http.Error(w, "creating temporary directory", http.StatusInternalServerError)
+		http.Error(w, "reading source", http.StatusInternalServerError)
 		return
 	}
 	defer os.RemoveAll(dir)
 
-	tmpSource := filepath.Join(dir, "play.zig")
-	if err := ioutil.WriteFile(tmpSource, []byte(zigSource), 0666); err != nil {
-		http.Error(w, "copying zig source", http.StatusInternalServerError)
-		return
-	}
-
 	// Currently we cap format times at ten seconds.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), maxCompTime)
 	defer cancel()
 
 	cmd := fmt.Sprintf("cat %s | %s fmt --stdin", tmpSource, zigExe)

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -25,7 +25,7 @@ func TestBodySizeLimit(t *testing.T) {
 			status, http.StatusInternalServerError)
 	}
 
-	expected := "reading body\n"
+	expected := "reading source\n"
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)

--- a/main.go
+++ b/main.go
@@ -42,7 +42,8 @@ func main() {
 
 	// We don't rate-limit the static files.
 	router.Handler(http.MethodPost, "/server/run", rlMiddle.Handle(http.HandlerFunc(Run)))
-
+	router.Handler(http.MethodPost, "/server/fmt", rlMiddle.Handle(http.HandlerFunc(Fmt)))
+	
 	chain := alice.New(securitySettings().Handler, handlers.CompressHandler).Then(router)
 	log.Fatal(http.ListenAndServe(":8080", chain))
 }

--- a/static/index.html
+++ b/static/index.html
@@ -54,7 +54,7 @@
 				} else if (!res.ok) {
 					msg = 'An error occurred:\n' + text;
 				} else if (res.ok) {	
-					msg = 'zig fmt successfull\n';
+					msg = 'zig fmt successful\n';
 					element.value = text;
 				}
 				

--- a/static/index.html
+++ b/static/index.html
@@ -34,6 +34,36 @@
 			}
 		}
 	}
+	async function fmtCode() {
+		const element = document.getElementById('code');
+		const stdout = document.getElementById('stdout');
+		if (element && stdout) {
+			const code = element.value;
+			try {
+				const res = await fetch('/server/fmt/', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'text/plain'
+					},
+					body: code
+				});
+				const text = await res.text();
+				let msg = text;
+				if (res.status === 429) {
+					msg = 'Too many requests. Please wait a minute and then try again.';
+				} else if (!res.ok) {
+					msg = 'An error occurred:\n' + text;
+				} else if (res.ok) {	
+					msg = 'zig fmt successfull\n';
+					element.value = text;
+				}
+				
+				stdout.innerHTML = msg;
+			} catch(e) {
+				stdout.innerHTML = 'Could not connect to server.'+e;
+			}
+		}
+	}
 	</script>
 </head>
 
@@ -43,6 +73,7 @@
 		<p>Source:</p>
 		<textarea id="code" placeholder="const std = ..." spellcheck="false">const std = @import("std"); pub fn main() void { std.debug.print("Hello, {s}!", .{"world"}); }</textarea>
 		<button onclick="runCode()">Compile</button>
+		<button onclick="fmtCode()">Format</button>
 		<div id="stdout"></div>
 	</main>
 </body>


### PR DESCRIPTION
Fixes: #10 

Now the playground includes a "Format" button to fun zig fmt on the user's source code similar to how we compile it. If the formatted code is different from the original code, it gets updated in the `textarea`. Likewise, If the code gets an error in `fmt`, the error message gets updated in `stdout`.

A new route `/server/fmt` is added which is similar to `/server/run` takes in the source as payload converts it to a file and now runs zig fmt on it with the same constraints as zig run with size & time.

It still has a few hiccups, like inadequate line number detection in the user's text area. Will try to improve on it in later PRs.