### PR TITLE
Fix Format Command

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -79,7 +79,8 @@ func execute(w http.ResponseWriter, r *http.Request, command Command) {
 	if command == R {
 		output, err = exec.CommandContext(ctx, zigExe, "run", "--global-cache-dir", dir, tmpSource).CombinedOutput()
 	} else {
-		cmd := fmt.Sprintf("cat %s | %s fmt --stdin", tmpSource, zigExe)
+		// The global cache directory option is not available for this command.
+		cmd := fmt.Sprintf("ZIG_GLOBAL_CACHE_DIR=%s cat %s | %s fmt --stdin", dir, tmpSource, zigExe)
 		output, err = exec.CommandContext(ctx, "bash", "-c", cmd).CombinedOutput()
 	}
 


### PR DESCRIPTION
With the most recent build, `zig fmt` is failing due to a permission error. This patch uses our temporary directory as a cache since we have a user who can not write to the default cache.