### PR TITLE
Better editor experience

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -1,54 +1,39 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Zig Playground</title>
-    <link rel="shortcut icon" type="image/x-icon" href="/logo.ico" />
-    <link rel="stylesheet" href="/style.css" type="text/css" />
-    <script>
-      async function execute(route) {
-        const element = document.getElementById('code');
-        const stdout = document.getElementById('stdout');
-        if (element && stdout) {
-          const code = element.value;
-          try {
-            const res = await fetch(route, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'text/plain'
-              },
-              body: code
-            });
-            const text = await res.text();
-            let msg = text;
-            if (res.status === 429) {
-              msg = 'Too many requests. Please wait a minute and then try again.';
-            } else if (!res.ok) {
-              msg = 'An error occurred:\n' + text;
-            }
-            stdout.innerHTML = msg;
-          } catch (e) {
-            stdout.innerHTML = 'Could not connect to server.';
-          }
-        }
-      }
-      async function runCode() {
-        execute('/server/run');
-      }
-      async function fmtCode() {
-        execute('/server/fmt');
-      }
-    </script>
-  </head>
-  <body>
-    <main>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Zig Playground</title>
+  <link rel="shortcut icon" type="image/x-icon" href="/logo.ico" />
+  <link rel="stylesheet" href="/style.css" type="text/css" />
+  <!-- Load ace editor from CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.37.5/src-min/ace.js"></script>
+  <script src="/playground.js"></script>
+</head>
+<body>
+  <main>
+    <div class="header">
       <h1>Zig Playground (###version###)</h1>
-      <p>Source:</p>
-      <textarea id="code" placeholder="const std = ..." spellcheck="false">const std = @import("std"); const builtin = @import("builtin"); pub fn main() void { std.debug.print("Hello, {s}! (using Zig version: {})", .{"world", builtin.zig_version}); }</textarea>
-      <button onclick="runCode()">Run</button>
-      <button onclick="fmtCode()">Format</button>
+      <div class="playground-controls">
+        <button onclick="runCode()">Run</button>
+        <button onclick="fmtCode()">Format</button>
+        <button onclick="toggleTheme()" id="toggle-light">Light</button>
+        <button onclick="toggleTheme()" id="toggle-dark">Dark</button>
+      </div>
+    </div>
+    <div id="playground">
+        <div id="editor" class="tab-content">// You can edit this code!
+// Click into the editor and start typing.
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn main() void {
+    std.debug.print("Hello, {s}! (using Zig version: {})", .{"world", builtin.zig_version});
+}
+</div>
       <div id="stdout"></div>
-    </main>
-  </body>
+    </div>
+  </main>
+</body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -11,6 +11,7 @@
   <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.37.5/src-min/ace.js"></script>
   <script src="/playground.js"></script>
 </head>
+
 <body>
   <main>
     <div class="header">
@@ -23,17 +24,12 @@
       </div>
     </div>
     <div id="playground">
-        <div id="editor" class="tab-content">// You can edit this code!
-// Click into the editor and start typing.
-const std = @import("std");
-const builtin = @import("builtin");
-
-pub fn main() void {
-    std.debug.print("Hello, {s}! (using Zig version: {})", .{"world", builtin.zig_version});
-}
-</div>
+      <!-- Our editor. -->
+      <div id="editor"></div>
+      <!-- Cmd output will be printed here. -->
       <div id="stdout"></div>
     </div>
   </main>
 </body>
+
 </html>

--- a/static/playground.js
+++ b/static/playground.js
@@ -79,9 +79,30 @@ function toggleTheme() {
     editor.setTheme(editorTheme);
 }
 
+/**
+ * Our demo code. Setting this up as a variable to keep the HTML clean.
+ * In the future, we can add a map of name/code pairs to allow a select
+ * list with various code examples. For example this snippet would be "hello world"
+ * but we would also allow them to select "zigg zagg" from the examples:
+ * 
+ * https://ziglang.org/learn/samples/
+ * */
+const demoCode = `// You can edit this code!
+// Click into the editor and start typing.
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub fn main() void {
+    std.debug.print("Hello, {s}! (using Zig version: {})", .{ "world", builtin.zig_version });
+}
+`; // Adding trailing space so it matches "format" output.
+
 // On content loaded, set up ace editor and detect dark/light mode and set data-theme appropriately.
 document.addEventListener('DOMContentLoaded', function () {
     editor = ace.edit("editor");
+    // Set the value of our editor to our demo code.
+    // The second param prevents default "select all" behavior.
+    editor.setValue(demoCode, -1);
     if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
         // dark mode
         editor.setTheme("ace/theme/vibrant_ink");

--- a/static/playground.js
+++ b/static/playground.js
@@ -1,0 +1,96 @@
+/**
+ *  Global ace editor variable.
+ */
+var editor;
+
+const runCmd = '/server/run';
+const fmtCmd = '/server/fmt';
+
+/**
+ * Execute a function.
+ * @param {string} route - The function to execute.
+ */
+async function execute(route) {
+    const stdout = document.getElementById('stdout');
+    if (!stdout) {
+        console.error("Couldn't find element #stdout.");
+        return;
+    }
+    stdout.innerHTML = "Waiting for server...";
+    const code = editor.getValue();
+    try {
+        const res = await fetch(route, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'text/plain'
+            },
+            body: code
+        });
+        const text = await res.text();
+        let msg = text;
+        if (res.status === 429) {
+            msg = 'Too many requests. Please wait a minute and then try again.';
+        } else if (!res.ok) {
+            msg = 'An error occurred:\n' + text;
+        }
+        // If run command, we display the resulting text.
+        if (route === runCmd) {
+            stdout.innerHTML = msg;
+        } else if (route === fmtCmd) {
+            // For format command, we set the editor text to the output and 
+            // let the user know the command is complete.
+            if (code != msg) {
+                // Preserve selection to try to put the cursor about where
+                // it was before format.
+                selection = editor.selection.toJSON();
+                editor.setValue(msg);
+                editor.selection.fromJSON(selection)
+            }
+            stdout.innerHTML = '';
+        }
+    } catch (e) {
+        stdout.innerHTML = 'Could not connect to server.';
+    }
+}
+
+/**
+ * Executes `runCmd` on the code in the editor.
+ */
+async function runCode() {
+    execute(runCmd);
+}
+
+/**
+ * Executes `fmtCmd` on the code in the editor then replaces the code in the editor with formatted code.
+ */
+async function fmtCode() {
+    execute(fmtCmd);
+}
+
+/**
+ * Toggle the dark/light theme.
+ */
+function toggleTheme() {
+    // Determine new value of toggle and set data-theme.
+    let newValue = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', newValue);
+    // Update our ace editor with new theme as well.
+    let editorTheme = newValue === 'dark' ? 'ace/theme/vibrant_ink' : 'ace/theme/clouds';
+    editor.setTheme(editorTheme);
+}
+
+// On content loaded, set up ace editor and detect dark/light mode and set data-theme appropriately.
+document.addEventListener('DOMContentLoaded', function () {
+    editor = ace.edit("editor");
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        // dark mode
+        editor.setTheme("ace/theme/vibrant_ink");
+        document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+        // light mode
+        editor.setTheme("ace/theme/clouds");
+        document.documentElement.setAttribute('data-theme', 'light');
+    }
+    // Set editor mode to zig.
+    editor.session.setMode("ace/mode/zig");
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,47 +1,102 @@
-* {
-     font-family: sans-serif;
+:root {
+    --background-color: #FFFFFF;
+    --color: #000000;
+    --border: rgb(171, 171, 171);
 }
 
- main {
-     display: block;
-     width: 80vw;
-     margin: 0 auto;
+/* Dark mode colors. */
+[data-theme="dark"] {
+    --background-color: #111;
+    --color: #bbb;
+    --border: rgb(83, 84, 85);
 }
 
- h1 {
-     font-size: 2.5rem;
+/* Don't show dark mode button when in dark mode */
+[data-theme="dark"] #toggle-dark {
+    display: none;
 }
 
- textarea, #stdout {
-     display: block;
-     padding: 1rem;
-     margin: 2rem 0;
-     font-family: monospace;
-     width: 50vw;
-     height: 20vh;
+/* Don't show light mode button when in light mode */
+[data-theme="light"] #toggle-light {
+    display: none;
 }
 
- textarea {
-     border: none;
-     background: #ddd;
+h1,
+p,
+button {
+    font-family: sans-serif;
 }
 
- #stdout {
-     border: 1px dashed gray;
-     overflow: scroll;
-     white-space: pre;
+div {
+    box-sizing: border-box;
 }
 
- button {
-     font-size: 1rem;
-     padding: 0.6rem;
-     border: none;
-     background: lightblue;
-     cursor: pointer;
+body {
+    color: var(--color);
+    background-color: var(--background-color);
 }
 
- @media only screen and (max-width: 800px) {
-     textarea, #stdout {
-         width: calc(80vw - 2rem);
+main {
+    display: block;
+    width: 90vw;
+    margin: 0 auto;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.playground-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-top: 0.4rem;
+}
+
+h1 {
+    font-size: 2.5rem;
+    margin-right: 0.5rem;
+}
+
+#stdout {
+    display: block;
+    padding: 1rem;
+    margin: 2rem 0;
+    font-family: monospace;
+    width: 100%;
+    height: 20vh;
+    border: 1px dashed gray;
+    overflow: scroll;
+    white-space: pre;
+}
+
+button {
+    font-size: 1rem;
+    padding: 0.6rem;
+    border: none;
+    background: lightblue;
+    cursor: pointer;
+}
+
+#playground {
+    display: flex;
+    flex-direction: column;
+}
+
+#editor {
+    border: solid 1px var(--border);
+    font-size: 0.8rem;
+    /* Ensure the font for ace editor is monospace! */
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'Source Code Pro', 'source-code-pro', monospace !important;
+    height: 60vh;
+}
+
+/* On smaller screen widths, the flex-based header and controls
+ * will start to wrap. Make our editor take up less height. */
+@media only screen and (max-width: 800px) {
+    #editor {
+        height: 50vh;
     }
 }


### PR DESCRIPTION
This is to try to get this to feel more like a web IDE. Closes #28. This adds the following:

- Change editor to Ace editor.
- Show indication we are waiting for the server when user performs an action.
- Detect OS' preference for light/dark theme and default to that.
- Allow users to switch between light/dark.
- On format, like Go playground, actually format code.

It borrows heavily from the Go playground. Here's what it looks like in light mode:

<img width="892" alt="Screenshot 2025-01-26 at 1 16 15 PM" src="https://github.com/user-attachments/assets/db244c3d-8fef-4212-9669-a9b20e3e6d5b" />

Here's dark mode (I tried to find a zig-ish theme; we can also just expose Ace's themes to the users):

<img width="891" alt="Screenshot 2025-01-26 at 1 15 51 PM" src="https://github.com/user-attachments/assets/3edbd861-451a-45c2-8bb9-ddcfe42ed2ff" />

I used a flex-based CSS layout which generally will resize down to phone screens:

<img width="353" alt="Screenshot 2025-01-26 at 1 18 25 PM" src="https://github.com/user-attachments/assets/f961284e-2e06-470e-846d-74022005cca3" />

Anyway, give it a try and tweak it to your liking.