### PR TITLE
Zig 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Test
       run: |
         go vet ./...

--- a/static/index.html
+++ b/static/index.html
@@ -16,8 +16,8 @@
             <div class="playground-controls">
                <label for="version-select">Version:</label>
                <select id="version-select" name="version-select">
+                  <option value="0.16.0" selected>0.16.0</option>
                   <option value="0.15.2" selected>0.15.2</option>
-                  <option value="0.14.1">0.14.1</option>
                   <option value="master">master</option>
                </select>
                <button onclick="runCode()">Run</button>


### PR DESCRIPTION
This patch adds version 0.16.0 and removes 0.14.2.